### PR TITLE
Improve handling of whitespace for alternatives

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -384,7 +384,7 @@ def missed(s: str) -> str:
 def not_code(s: str) -> str:
     return f"</code>{s}<code id=typeans>"
 
-def strip_segment_whitespace(segment: list[str], alphaBefore: bool, alphaAfter: bool) -> list[str]:
+def strip_segment_whitespace(segment: list[str], alpha_before: bool, alpha_after: bool) -> list[str]:
     """Strip whitespace from ends of a segment which are next to whitespace."""
 
     # Find start and end of fully stripped segment
@@ -404,16 +404,16 @@ def strip_segment_whitespace(segment: list[str], alphaBefore: bool, alphaAfter: 
         return []
 
     # If no whitespace before segment, don't strip start
-    if alphaBefore:
+    if alpha_before:
         start = None
 
     # If no whitespace after segment, don't strip end
-    if alphaAfter:
+    if alpha_after:
         end = None
 
     return segment[start:end]
 
-def is_alternative(segment: list[str], alphaBefore: bool, alphaAfter: bool) -> bool:
+def is_alternative(segment: list[str], alpha_before: bool, alpha_after: bool) -> bool:
     """
     Check if a missing segment is part of an alternative. An alternative is
     a series of single words separated by slashes, which allows the user to
@@ -425,7 +425,7 @@ def is_alternative(segment: list[str], alphaBefore: bool, alphaAfter: bool) -> b
     segment = list(filter(lambda ch: ch in whitespace_chars or not is_junk(ch), segment))
 
     # Strip whitespace on ends which already have whitespace
-    segment = strip_segment_whitespace(segment, alphaBefore, alphaAfter)
+    segment = strip_segment_whitespace(segment, alpha_before, alpha_after)
 
     if not segment:
         return False
@@ -448,11 +448,11 @@ def is_alternative(segment: list[str], alphaBefore: bool, alphaAfter: bool) -> b
     if last != '/' and not last.isalpha():
         return False
 
-    expectAlphaBefore = first == '/'
-    expectAlphaAfter = last == '/'
+    expect_alpha_before = first == '/'
+    expect_alpha_after = last == '/'
 
     # There should be an alphabetic character only next to slashes
-    return alphaBefore == expectAlphaBefore and alphaAfter == expectAlphaAfter
+    return alpha_before == expect_alpha_before and alpha_after == expect_alpha_after
 
 def remove_bracketed_text(segment: list[str]) -> list[str]:
     """Remove all bracketed text from a segment."""
@@ -467,7 +467,7 @@ def remove_bracketed_text(segment: list[str]) -> list[str]:
 
     return result
 
-def is_missing_allowed(segment: list[str], alphaBefore: bool, alphaAfter: bool) -> bool:
+def is_missing_allowed(segment: list[str], alpha_before: bool, alpha_after: bool) -> bool:
     """
     Check whether a segment of text is allowed to be missing. If it is allowed
     to be missing, then it will not be reported as incorrect if it is missing.
@@ -486,7 +486,7 @@ def is_missing_allowed(segment: list[str], alphaBefore: bool, alphaAfter: bool) 
         return True
 
     # Alternatives like "/abc", "/abc/def", and "abc/" can be missing
-    return is_alternative(segment, alphaBefore, alphaAfter)
+    return is_alternative(segment, alpha_before, alpha_after)
 
 def isalpha_at_index(s: list[str], i: int) -> bool:
     return 0 <= i < len(s) and s[i].isalpha()
@@ -528,11 +528,11 @@ def render_diffs(given, correct, given_elems, correct_elems):
 
             # If completely missing in "given", add hyphen
             if given_index == i:
-                alphaBefore = isalpha_at_index(correct, correct_index - 1)
-                alphaAfter = isalpha_at_index(correct, j)
+                alpha_before = isalpha_at_index(correct, correct_index - 1)
+                alpha_after = isalpha_at_index(correct, j)
 
                 # Check if should be ignored with lenient validation
-                if not is_missing_allowed(correct[correct_index:j], alphaBefore, alphaAfter):
+                if not is_missing_allowed(correct[correct_index:j], alpha_before, alpha_after):
                     has_error = True
                     given_elem += bad('-')
 

--- a/test/test_issue_regression.py
+++ b/test/test_issue_regression.py
@@ -6,6 +6,18 @@ def test_issue_2_alternative():
     result = compare_answer_no_html(correct, given)
     assert result == '<div><code id=typeans><span class=typeGood>be set in </span><span class=typeMissed>one&#x27;s/</span><span class=typeGood>my ways</span></code></div>'
 
+def test_issue_2_alternative_in_brackets_first():
+    correct = "There's no need to hurry - we've got [a lot of/plenty of] time."
+    given = "There's no need to hurry - we've got a lot of time."
+    result = compare_answer_no_html(correct, given)
+    assert result == '<div><code id=typeans><span class=typeGood>There&#x27;s no need to hurry - we&#x27;ve got </span><span class=typeMissed>[</span><span class=typeGood>a lot of</span><span class=typeMissed>/plenty of]</span><span class=typeGood> time.</span></code></div>'
+
+def test_issue_2_alternative_in_brackets_second():
+    correct = "There's no need to hurry - we've got [a lot of/plenty of] time."
+    given = "There's no need to hurry - we've got plenty of time."
+    result = compare_answer_no_html(correct, given)
+    assert result == '<div><code id=typeans><span class=typeGood>There&#x27;s no need to hurry - we&#x27;ve got </span><span class=typeMissed>[a lot of/</span><span class=typeGood>plenty of</span><span class=typeMissed>]</span><span class=typeGood> time.</span></code></div>'
+
 def test_issue_3_starting():
     correct = 'start(ing)'
     given = 'start'
@@ -47,3 +59,27 @@ def test_issue_10_separators_in_brackets():
     given = 'kler på (meg, Xen, ...)'
     result = compare_answer_no_html(correct, given)
     assert result == '<div><code id=typeans><span class=typeGood>kler på (meg</span><span class=typeMissed>/deg/seg/oss</span><span class=typeGood>, Xen, ...)</span></code></div>'
+
+def test_issue_13_alternative_in_bracket_in_word_first():
+    correct = 'tar en (master/bachelor)grad i X'
+    given = 'tar en mastergrad i X'
+    result = compare_answer_no_html(correct, given)
+    assert result == '<div><code id=typeans><span class=typeGood>tar en </span><span class=typeMissed>(</span><span class=typeGood>master</span><span class=typeMissed>/bachelor)</span><span class=typeGood>grad i X</span></code></div>'
+
+def test_issue_13_alternative_in_bracket_in_word_second():
+    correct = 'tar en (master/bachelor)grad i X'
+    given = 'tar en bachelorgrad i X'
+    result = compare_answer_no_html(correct, given)
+    assert result == '<div><code id=typeans><span class=typeGood>tar en </span><span class=typeMissed>(master/</span><span class=typeGood>bachelor</span><span class=typeMissed>)</span><span class=typeGood>grad i X</span></code></div>'
+
+def test_issue_13_alternative_in_bracket_in_word_both():
+    correct = 'tar en (master/bachelor)grad i X'
+    given = 'tar en master/bachelorgrad i X'
+    result = compare_answer_no_html(correct, given)
+    assert result == '<div><code id=typeans><span class=typeGood>tar en </span><span class=typeMissed>(</span><span class=typeGood>master/bachelor</span><span class=typeMissed>)</span><span class=typeGood>grad i X</span></code></div>'
+
+def test_issue_13_alternative_in_bracket_in_word_neither():
+    correct = 'tar en (master/bachelor)grad i X'
+    given = 'tar en grad i X'
+    result = compare_answer_no_html(correct, given)
+    assert result == '<div><code id=typeans><span class=typeGood>tar en </span><span class=typeMissed>(master/bachelor)</span><span class=typeGood>grad i X</span></code></div>'

--- a/test/test_lenient_validation.py
+++ b/test/test_lenient_validation.py
@@ -71,3 +71,27 @@ def test_missing_alternative_end_with_brackets():
     given = 'test ghi test'
     result = compare_answer_no_html(correct, given)
     assert result == '<div><code id=typeans><span class=typeGood>test </span><span class=typeMissed>[wx yz]. abc/def/</span><span class=typeGood>ghi test</span></code></div>'
+
+def test_missing_alternative_in_word_with_brackets():
+    correct = 'test word(abc/def/ghi)word test'
+    given = 'test worddefword test'
+    result = compare_answer_no_html(correct, given)
+    assert result == '<div><code id=typeans><span class=typeGood>test word</span><span class=typeMissed>(abc/</span><span class=typeGood>def</span><span class=typeMissed>/ghi)</span><span class=typeGood>word test</span></code></div>'
+
+def test_missing_alternative_with_spaces_in_brackets():
+    correct = 'test [a b c/d e f/g h i] test'
+    given = 'test d e f test'
+    result = compare_answer_no_html(correct, given)
+    assert result == '<div><code id=typeans><span class=typeGood>test </span><span class=typeMissed>[a b c/</span><span class=typeGood>d e f</span><span class=typeMissed>/g h i]</span><span class=typeGood> test</span></code></div>'
+
+def test_missing_alternative_with_spaces_not_in_brackets():
+    correct = 'test a b c/d e f/g h i test'
+    given = 'test d e f test'
+    result = compare_answer_no_html(correct, given)
+    assert 'typearrow' in result
+
+def test_missing_alternative_with_junk_before_slash():
+    correct = 'test abc-/def/ghi test'
+    given = 'test abc test'
+    result = compare_answer_no_html(correct, given)
+    assert 'typearrow' in result


### PR DESCRIPTION
This change will allow alternatives to be used inside of brackets immediately next to words, such as `tar en (master/bachelor)grad`, so it should resolve #13 by accepting `mastergrad`, `bachelorgrad`, and `grad`.

Spaces are now also allowed in alternatives when they are surrounded by brackets, as suggested in #2, although this functionality may not work perfectly in every scenario. For instance, `we have [a lot of/plenty of] time` accepts both `a lot of` and `plenty of` now, but it also still accepts `a lot plenty of` and `a lot of of` since it is ambiguous which interpretation is correct. Also, bracketed text is still allowed to be missing, so `we have time` would also be accepted.