### PR TITLE
Change implementation of alternatives

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Scott Taylor
+Copyright (c) 2024 Scott Taylor
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This add-on is implemented as a monkey patch replacing
 `Collection.compare_answer` (Anki 2.1.56+) or `Reviewer.correct` (up to Anki
 2.1.54), which are responsible for generating the differences. Since it replaces
 these functions, it is not guaranteed to work in future updates. I have tested
-it in Anki 2.1.40 through 2.1.65.
+it in Anki 2.1.40 through Anki 23.12.1.
 
 The answer rearranging algorithm uses the
 [Longest Common Subsequence](https://en.wikipedia.org/wiki/Longest_common_subsequence)
@@ -75,6 +75,10 @@ a similar algorithm to the default implementation. Comments are only compared if
 they are given when typing the answer in.
 
 ## Changelog
+
+2024-01-08:
+
+* Use new implementation for alternatives to fix issue.
 
 2023-12-27:
 

--- a/test/test_issue_regression.py
+++ b/test/test_issue_regression.py
@@ -83,3 +83,39 @@ def test_issue_13_alternative_in_bracket_in_word_neither():
     given = 'tar en grad i X'
     result = compare_answer_no_html(correct, given)
     assert result == '<div><code id=typeans><span class=typeGood>tar en </span><span class=typeMissed>(master/bachelor)</span><span class=typeGood>grad i X</span></code></div>'
+
+def test_issue_16_adjacent_bracketed_alternatives_1():
+    correct = 'point(ing/s) (at)'
+    given = 'pointing at'
+    result = compare_answer_no_html(correct, given)
+    assert result == '<div><code id=typeans><span class=typeGood>point</span><span class=typeMissed>(</span><span class=typeGood>ing</span><span class=typeMissed>/s)</span><span class=typeGood> </span><span class=typeMissed>(</span><span class=typeGood>at</span><span class=typeMissed>)</span></code></div>'
+
+def test_issue_16_adjacent_bracketed_alternatives_2():
+    correct = 'point(ing/s) (at)'
+    given = 'pointing'
+    result = compare_answer_no_html(correct, given)
+    assert result == '<div><code id=typeans><span class=typeGood>point</span><span class=typeMissed>(</span><span class=typeGood>ing</span><span class=typeMissed>/s) (at)</span></code></div>'
+
+def test_issue_16_adjacent_bracketed_alternatives_3():
+    correct = 'point(ing/s) (at)'
+    given = 'points at'
+    result = compare_answer_no_html(correct, given)
+    assert result == '<div><code id=typeans><span class=typeGood>point</span><span class=typeMissed>(ing/</span><span class=typeGood>s</span><span class=typeMissed>)</span><span class=typeGood> </span><span class=typeMissed>(</span><span class=typeGood>at</span><span class=typeMissed>)</span></code></div>'
+
+def test_issue_16_adjacent_bracketed_alternatives_4():
+    correct = 'point(ing/s) (at)'
+    given = 'points'
+    result = compare_answer_no_html(correct, given)
+    assert result == '<div><code id=typeans><span class=typeGood>point</span><span class=typeMissed>(ing/</span><span class=typeGood>s</span><span class=typeMissed>) (at)</span></code></div>'
+
+def test_issue_16_adjacent_bracketed_alternatives_5():
+    correct = 'point(ing/s) (at)'
+    given = 'point at'
+    result = compare_answer_no_html(correct, given)
+    assert result == '<div><code id=typeans><span class=typeGood>point</span><span class=typeMissed>(ing/s)</span><span class=typeGood> </span><span class=typeMissed>(</span><span class=typeGood>at</span><span class=typeMissed>)</span></code></div>'
+
+def test_issue_16_adjacent_bracketed_alternatives_6():
+    correct = 'point(ing/s) (at)'
+    given = 'point'
+    result = compare_answer_no_html(correct, given)
+    assert result == '<div><code id=typeans><span class=typeGood>point</span><span class=typeMissed>(ing/s) (at)</span></code></div>'

--- a/test/test_lenient_validation.py
+++ b/test/test_lenient_validation.py
@@ -95,3 +95,31 @@ def test_missing_alternative_with_junk_before_slash():
     given = 'test abc test'
     result = compare_answer_no_html(correct, given)
     assert 'typearrow' in result
+
+def test_several_lenient_validation_together():
+    options = [
+        ('aa/bb/cc ', 'aa '),
+        ('aa/bb/cc ', 'aa/bb '),
+        ('aa/bb/cc ', 'aa/cc '),
+        ('aa/bb/cc ', 'bb '),
+        ('aa/bb/cc ', 'bb/cc '),
+        ('aa/bb/cc ', 'cc '),
+        ('[aa/bb/cc] ', 'aa '),
+        ('[aa/bb/cc] ', 'aa/bb '),
+        ('[aa/bb/cc] ', 'aa/cc '),
+        ('[aa/bb/cc] ', 'bb '),
+        ('[aa/bb/cc] ', 'bb/cc '),
+        ('[aa/bb/cc] ', 'cc '),
+        ('[aa/bb/cc] ', ''),
+    ]
+
+    bTrans = str.maketrans('abc', 'def')
+    cTrans = str.maketrans('abc', 'ghi')
+
+    for correctA, givenA in options:
+        for correctB, givenB in options:
+            for correctC, givenC in options:
+                correct = f'x {correctA}{correctB.translate(bTrans)}{correctC.translate(cTrans)}y'
+                given = f'x {givenA}{givenB.translate(bTrans)}{givenC.translate(cTrans)}y'
+                result = compare_answer_no_html(correct, given)
+                assert 'typearrow' not in result, f'{given} :: {correct}'


### PR DESCRIPTION
This PR should resolve #16 by simplifying the implementation of alternatives to avoid edge cases with the old implementation, and by matching on junk characters such as spaces in the `SequenceMatcher`.