### PR TITLE
Treat spaces as junk characters to fix alternative diffing

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ they are given when typing the answer in.
 
 ## Changelog
 
+2024-01-14:
+
+* Fix issue with finding differences for certain alternatives.
+
 2024-01-08:
 
 * Use new implementation for alternatives to fix issue.

--- a/doc/lenient_validation.md
+++ b/doc/lenient_validation.md
@@ -37,7 +37,9 @@ And if you type "starting" for `start(ing)`, it shows:
 Sometimes there may be multiple similar words in an answer which are all
 correct. If you separate these words with slashes (`/`), lenient validation
 will accept any one of them, and will not mark the missing alternatives as
-incorrect.
+incorrect. Note: if one of the words is a part of the other, make sure to put
+it first or it may not always work properly. For instance, use `a/an` instead
+of `an/a`, and use `start/starting` instead of `starting/start`.
 
 For example, if you type "set in my ways" for `set in one's/my ways`, it shows:
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2023 Scott Taylor
+# Copyright (c) 2024 Scott Taylor
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -404,7 +404,7 @@ def find_potential_alternative_end(segment: list[str], bracket_start_chars: str,
 
     for i, ch in enumerate(segment):
         if require_alpha and not ch.isalpha():
-            return None
+            return end
 
         require_alpha = ch == '/'
 
@@ -420,10 +420,7 @@ def find_potential_alternative_end(segment: list[str], bracket_start_chars: str,
         if end is None and ch in whitespace_chars:
             end = i
 
-    if require_alpha:
-        return None
-
-    if end is None and not alpha_after:
+    if end is None and not require_alpha and not alpha_after:
         return len(segment)
 
     return end

--- a/test/test_issue_regression.py
+++ b/test/test_issue_regression.py
@@ -88,7 +88,7 @@ def test_issue_16_adjacent_bracketed_alternatives_1():
     correct = 'point(ing/s) (at)'
     given = 'pointing at'
     result = compare_answer_no_html(correct, given)
-    assert result == '<div><code id=typeans><span class=typeGood>point</span><span class=typeMissed>(</span><span class=typeGood>ing</span><span class=typeMissed>/s)</span><span class=typeGood> </span><span class=typeMissed>(</span><span class=typeGood>at</span><span class=typeMissed>)</span></code></div>'
+    assert result == '<div><code id=typeans><span class=typeGood>point</span><span class=typeMissed>(</span><span class=typeGood>ing</span><span class=typeMissed>/s) (</span><span class=typeGood>at</span><span class=typeMissed>)</span></code></div>'
 
 def test_issue_16_adjacent_bracketed_alternatives_2():
     correct = 'point(ing/s) (at)'
@@ -100,7 +100,7 @@ def test_issue_16_adjacent_bracketed_alternatives_3():
     correct = 'point(ing/s) (at)'
     given = 'points at'
     result = compare_answer_no_html(correct, given)
-    assert result == '<div><code id=typeans><span class=typeGood>point</span><span class=typeMissed>(ing/</span><span class=typeGood>s</span><span class=typeMissed>)</span><span class=typeGood> </span><span class=typeMissed>(</span><span class=typeGood>at</span><span class=typeMissed>)</span></code></div>'
+    assert result == '<div><code id=typeans><span class=typeGood>point</span><span class=typeMissed>(ing/</span><span class=typeGood>s</span><span class=typeMissed>) (</span><span class=typeGood>at</span><span class=typeMissed>)</span></code></div>'
 
 def test_issue_16_adjacent_bracketed_alternatives_4():
     correct = 'point(ing/s) (at)'
@@ -112,10 +112,40 @@ def test_issue_16_adjacent_bracketed_alternatives_5():
     correct = 'point(ing/s) (at)'
     given = 'point at'
     result = compare_answer_no_html(correct, given)
-    assert result == '<div><code id=typeans><span class=typeGood>point</span><span class=typeMissed>(ing/s)</span><span class=typeGood> </span><span class=typeMissed>(</span><span class=typeGood>at</span><span class=typeMissed>)</span></code></div>'
+    assert result == '<div><code id=typeans><span class=typeGood>point</span><span class=typeMissed>(ing/s) (</span><span class=typeGood>at</span><span class=typeMissed>)</span></code></div>'
 
 def test_issue_16_adjacent_bracketed_alternatives_6():
     correct = 'point(ing/s) (at)'
     given = 'point'
     result = compare_answer_no_html(correct, given)
     assert result == '<div><code id=typeans><span class=typeGood>point</span><span class=typeMissed>(ing/s) (at)</span></code></div>'
+
+def test_issue_18_overlapping_alternatives_1():
+    correct = 'apprenticeship as a/an X'
+    given = 'apprenticeship as a X'
+    result = compare_answer_no_html(correct, given)
+    assert result == '<div><code id=typeans><span class=typeGood>apprenticeship as a</span><span class=typeMissed>/an</span><span class=typeGood> X</span></code></div>'
+
+def test_issue_18_overlapping_alternatives_2():
+    correct = 'apprenticeship as a/an X'
+    given = 'apprenticeship as an X'
+    result = compare_answer_no_html(correct, given)
+    assert result == '<div><code id=typeans><span class=typeGood>apprenticeship as </span><span class=typeMissed>a/</span><span class=typeGood>an X</span></code></div>'
+
+def test_issue_18_overlapping_alternatives_3():
+    correct = 'apprenticeship as an/a X'
+    given = 'apprenticeship as an X'
+    result = compare_answer_no_html(correct, given)
+    assert result == '<div><code id=typeans><span class=typeGood>apprenticeship as an</span><span class=typeMissed>/a</span><span class=typeGood> X</span></code></div>'
+
+def test_issue_18_overlapping_alternatives_4():
+    correct = 'start/starting'
+    given = 'start'
+    result = compare_answer_no_html(correct, given)
+    assert result == '<div><code id=typeans><span class=typeGood>start</span><span class=typeMissed>/starting</span></code></div>'
+
+def test_issue_18_overlapping_alternatives_5():
+    correct = 'start/starting'
+    given = 'starting'
+    result = compare_answer_no_html(correct, given)
+    assert result == '<div><code id=typeans><span class=typeMissed>start/</span><span class=typeGood>starting</span></code></div>'


### PR DESCRIPTION
In #17, I changed spaces to not be treated as junk characters in an attempt to fix an issue with parsing consecutive alternatives. That solution caused another issue (#18), so now I am trying another possible solution. Now it will check for cases where the incorrect "given" text is contained in the missing "correct" text and treat it as just being missing.