### PR TITLE
Improve handling of Unicode characters in config and diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ before showing the difference, and so only this would be shown:
 This is particularly useful for language learning, since often there will be
 multiple words matching a definition or multiple definitions for the same word.
 
+## Lenient Validation
+
+This add-on also makes it possible to mark certain words in an answer as
+optional by putting them in parentheses or square brackets, or to accept any
+one of a set of words within an answer by separating them with slashes.
+[See here](doc/lenient_validation.md) for more details.
+
 ## Improved Support for Indic Scripts
 
 For some languages such as Tamil (தமிழ்), the script requires combining
@@ -85,6 +92,11 @@ validation", where brackets, text separated by slashes, and certain other
 characters are allowed to be missing from the given answer.
 
 ## Changelog
+
+2024-02-20:
+
+* Use Unicode case folding for case-insensitive matching.
+* Fixed Unicode normalization in config options.
 
 2024-02-08:
 

--- a/answerset/arrange.py
+++ b/answerset/arrange.py
@@ -157,10 +157,10 @@ class Arranger:
                 if s == max_similarity:
                     break
 
-        # Record the assignment
         if closest is None:
             return False
 
+        # Record the assignment
         target = self.closest[closest]
         self.assigned[closest] = target
         self.used.add(target)

--- a/answerset/config.py
+++ b/answerset/config.py
@@ -1,4 +1,5 @@
 import re
+import unicodedata as ucd
 from typing import Any, TypeVar
 
 from .group import group_combining
@@ -27,7 +28,7 @@ def get_equivalent_strings_config_var(config: Any, var_name: str, default_value:
                 [
                     [
                         lowercase_if_ignore_case(ch, ignore_case)
-                        for ch in group_combining(x)
+                        for ch in group_combining(ucd.normalize('NFC', x))
                     ]
                     for x in xs
                     if x and type(x) is str
@@ -46,7 +47,7 @@ class Config:
         self.ignore_case = get_config_var(config, 'Ignore Case', True)
         self.ignore_separators_in_brackets = get_config_var(config, 'Ignore Separators in Brackets', True)
 
-        self.ignored_characters = lowercase_if_ignore_case(get_config_var(config, 'Ignored Characters', ' .-'), self.ignore_case)
+        self.ignored_characters = ucd.normalize('NFC', lowercase_if_ignore_case(get_config_var(config, 'Ignored Characters', ' .-'), self.ignore_case))
         self.equivalent_strings = get_equivalent_strings_config_var(config, 'Equivalent Strings', [], self.ignore_case)
         self.diff_lookbehind = max(1, max((len(x) for xs in self.equivalent_strings for x in xs), default=0))
 

--- a/answerset/group.py
+++ b/answerset/group.py
@@ -26,3 +26,10 @@ def group_combining(string: str) -> list[str]:
         parts.append(current)
 
     return parts
+
+def has_multiple_chars(string: str) -> bool:
+    for i in range(1, len(string)):
+        if not is_combining(string[i]):
+            return True
+
+    return False

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -40,6 +40,17 @@ def test_equivalent_strings_ignore_case():
     result = compare_answer_no_html(config, correct, given)
     assert 'typearrow' not in result
 
+def test_equivalent_strings_ignore_case_unicode():
+    correct = 'xß'
+    given = 'y'
+    config = Config({
+        "Equivalent Strings": [
+            ["xß", "y"],
+        ],
+    })
+    result = compare_answer_no_html(config, correct, given)
+    assert 'typearrow' not in result
+
 def test_equivalent_strings_no_ignore_case():
     correct = 'dog and moose'
     given = 'CAT and MOUSE'
@@ -79,6 +90,13 @@ def test_equivalent_strings_normalization_2():
 def test_ignore_case():
     correct = 'I saw him'
     given = 'i saw Him'
+    config = Config()
+    result = compare_answer_no_html(config, correct, given)
+    assert 'typearrow' not in result
+
+def test_ignore_case_unicode():
+    correct = 'xßy'
+    given = 'xssy'
     config = Config()
     result = compare_answer_no_html(config, correct, given)
     assert 'typearrow' not in result

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -53,6 +53,29 @@ def test_equivalent_strings_no_ignore_case():
     result = compare_answer_no_html(config, correct, given)
     assert 'typearrow' not in result
 
+def test_equivalent_strings_normalization_1():
+    correct = '\u212B'
+    given = 'A'
+    config = Config({
+        "Equivalent Strings": [
+            ["A", "A\u030A"]
+        ],
+    })
+    result = compare_answer_no_html(config, correct, given)
+    assert 'typearrow' not in result
+
+def test_equivalent_strings_normalization_2():
+    correct = 'A\u030A'
+    given = 'A'
+    config = Config({
+        "Equivalent Strings": [
+            ["A", "\u212B"]
+        ],
+        "Ignore Case": False,
+    })
+    result = compare_answer_no_html(config, correct, given)
+    assert 'typearrow' not in result
+
 def test_ignore_case():
     correct = 'I saw him'
     given = 'i saw Him'
@@ -93,3 +116,22 @@ def test_missing_space_not_ignored():
     })
     result = compare_answer_no_html(config, correct, given)
     assert 'typearrow' in result
+
+def test_ignored_characters_normalization_1():
+    correct = 'test \u212B'
+    given = 'test'
+    config = Config({
+        "Ignored Characters": "A\u030A ",
+    })
+    result = compare_answer_no_html(config, correct, given)
+    assert 'typearrow' not in result
+
+def test_ignored_characters_normalization_2():
+    correct = 'test A\u030A'
+    given = 'test'
+    config = Config({
+        "Ignore Case": False,
+        "Ignored Characters": "\u212B ",
+    })
+    result = compare_answer_no_html(config, correct, given)
+    assert 'typearrow' not in result


### PR DESCRIPTION
This PR normalizes config strings to NFC since answers are always normalized to NFC before comparisons, and it also uses Unicode case folding for case-insensitive comparisons (instead of just using lowercase).