### PR TITLE
Separator improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ for rearranging. Otherwise, `,` will be used. This means that this:
 a, b, c; d, e, f
 ```
 
-Will be parsed into `a, b, c` as one answer and `d, e, f` as another.
+Will be parsed into `a, b, c` as one answer and `d, e, f` as another. If you
+want to use different answer choice separators, you can configure them in the
+Anki add-on config page.
 
 ## Config
 
@@ -93,6 +95,10 @@ validation", where brackets, text separated by slashes, and certain other
 characters are allowed to be missing from the given answer.
 
 ## Changelog
+
+2024-03-18:
+
+* Added config option to change answer choice separators.
 
 2024-03-17:
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ characters are allowed to be missing from the given answer.
 2024-03-18:
 
 * Added config option to change answer choice separators.
+* Improved handling of missing answer choice separators.
 
 2024-03-17:
 

--- a/answerset/config.json
+++ b/answerset/config.json
@@ -6,5 +6,6 @@
     "Ignore Case": true,
     "Ignore Separators in Brackets": true,
     "Ignored Characters": " .-",
-    "Numeric Comparison Factor": 1.0
+    "Numeric Comparison Factor": 1.0,
+    "Separators": ";,"
 }

--- a/answerset/config.md
+++ b/answerset/config.md
@@ -83,3 +83,15 @@ equivalent to a factor of 1.25.
 
 If this option is set to 0, then numeric comparisons will be disabled entirely,
 meaning that numbers will be compared as strings of digits only.
+
+## Separators
+
+This option configures which characters can be used to separate answer choices.
+The default value is `";,"`, meaning that if there are any semicolons, then
+semicolons will be used as the answer separator, otherwise if there are any
+commas, then commas will be used, otherwise answers will not be split at all.
+
+If you want to answer in full sentences, it may be a good idea to change this
+to `";"` to prevent commas from being misinterpreted. If you only use this
+add-on for other features, you could even set it to `""` to prevent any answers
+from being split into choices.

--- a/answerset/config.py
+++ b/answerset/config.py
@@ -52,6 +52,7 @@ class Config:
         self.ignore_case = get_config_var(config, 'Ignore Case', True)
         self.ignore_separators_in_brackets = get_config_var(config, 'Ignore Separators in Brackets', True)
         self.numeric_comparison_factor = get_config_var(config, 'Numeric Comparison Factor', 0.0)
+        self.separators = get_config_var(config, 'Separators', ';,')
 
         self.ignored_characters = ucd.normalize('NFC', casefold_if_ignore_case(get_config_var(config, 'Ignored Characters', ' .-'), self.ignore_case))
         self.equivalent_strings = get_equivalent_strings_config_var(config, 'Equivalent Strings', [], self.ignore_case)

--- a/answerset/util.py
+++ b/answerset/util.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterable
+from typing import Optional
 
 from .config import Config
 
@@ -42,7 +43,10 @@ def find_indices(haystack: str, needle: str, ranges: list[tuple[int, int]]) -> I
 def has_separator(string: str, sep: str, bracket_ranges: list[tuple[int, int]]) -> bool:
     return any(True for _ in find_indices(string, sep, bracket_ranges))
 
-def split_except_for_ranges(string: str, sep: str, ranges: list[tuple[int, int]]) -> list[str]:
+def split_except_for_ranges(string: str, sep: Optional[str], ranges: list[tuple[int, int]]) -> list[str]:
+    if not sep:
+        return [string]
+
     sep_indices = list(find_indices(string, sep, ranges))
 
     if not sep_indices:

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -153,3 +153,30 @@ def test_ignored_characters_normalization_2() -> None:
     })
     result = compare_answer_no_html(config, correct, given)
     assert 'typearrow' not in result
+
+def test_separator_first_choice() -> None:
+    correct = 'a2b1c2d'
+    given = 'c2d1a2b'
+    config = Config({
+        "Separators": "123",
+    })
+    result = compare_answer_no_html(config, correct, given)
+    assert 'typearrow' not in result
+
+def test_separator_last_choice() -> None:
+    correct = 'abc3def'
+    given = 'def3abc'
+    config = Config({
+        "Separators": "123",
+    })
+    result = compare_answer_no_html(config, correct, given)
+    assert 'typearrow' not in result
+
+def test_separator_none() -> None:
+    correct = 'abc, def'
+    given = 'def, abc'
+    config = Config({
+        "Separators": "",
+    })
+    result = compare_answer_no_html(config, correct, given)
+    assert 'typearrow' in result

--- a/test/test_issue_regression.py
+++ b/test/test_issue_regression.py
@@ -255,6 +255,30 @@ def test_issue_23_equivalent_strings() -> None:
     result = compare_answer_no_html(config, correct, given)
     assert result == '<div id=typeans><code><span class=typeGood>I am happy</span><span class=typeMissed>.</span></code></div>'
 
+def test_issue_28_with_separator() -> None:
+    correct = 'Da pappa var ung, besøkte han oslo om sommeren.'
+    given = 'Da pappa var ung, besøkte han oslo om sommeren'
+    result = compare_answer_no_html(test_config, correct, given)
+    assert result == '<div id=typeans><code><span class=typeGood>Da pappa var ung</span></code>, <code><span class=typeGood>besøkte han oslo om sommeren</span><span class=typeMissed>.</span></code></div>'
+
+def test_issue_28_disabled_separator() -> None:
+    correct = 'Da pappa var ung, besøkte han oslo om sommeren.'
+    given = 'Da pappa var ung, besøkte han oslo om sommeren'
+    config = Config({
+        "Separators": "",
+    })
+    result = compare_answer_no_html(config, correct, given)
+    assert result == '<div id=typeans><code><span class=typeGood>Da pappa var ung, besøkte han oslo om sommeren</span><span class=typeMissed>.</span></code></div>'
+
+def test_issue_28_missing_separator() -> None:
+    correct = 'Da pappa var ung, besøkte han oslo om sommeren.'
+    given = 'Da pappa var ung besøkte han oslo om sommeren'
+    config = Config({
+        "Ignored Characters": ",. ",
+    })
+    result = compare_answer_no_html(config, correct, given)
+    assert result == '<div id=typeans><code><span class=typeGood>Da pappa var ung</span><span class=typeMissed>,</span><span class=typeGood> besøkte han oslo om sommeren</span><span class=typeMissed>.</span></code></div>'
+
 def test_issue_31_slash_separator() -> None:
     correct = 'a,b / c,d'
     given = 'c,d/a,b'

--- a/test/test_issue_regression.py
+++ b/test/test_issue_regression.py
@@ -254,3 +254,12 @@ def test_issue_23_equivalent_strings() -> None:
     })
     result = compare_answer_no_html(config, correct, given)
     assert result == '<div id=typeans><code><span class=typeGood>I am happy</span><span class=typeMissed>.</span></code></div>'
+
+def test_issue_31_slash_separator() -> None:
+    correct = 'a,b / c,d'
+    given = 'c,d/a,b'
+    config = Config({
+        "Separators": "/",
+    })
+    result = compare_answer_no_html(config, correct, given)
+    assert result == '<div id=typeans><code><span class=typeGood>c,d</span></code> / <code><span class=typeGood>a,b</span></code></div>'


### PR DESCRIPTION
This PR adds a check to see whether a better diff could be found by ignoring separators, and if so, it ignores separators, which should resolve #28. Additionally, it adds a new config option for which characters are used as separators, which should also resolve #31.