### PR TITLE
Add test coverage check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest mypy aqt[qt6]
+          pip install pytest pytest-cov mypy aqt[qt6]
 
       - name: Test and build add-on
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__
 .*_cache
+.coverage
 answerset.ankiaddon
 pytest-junit.xml

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,10 @@ OUTPUT_FILE = answerset.ankiaddon
 TEST_REPORT_FILE = pytest-junit.xml
 
 GENERATED_FILES = $(TEST_REPORT_FILE) $(OUTPUT_FILE)
-CACHE_DIRS = answerset/__pycache__ test/__pycache__ .pytest_cache .mypy_cache
+CACHE_DIRS = answerset/__pycache__ test/__pycache__ .pytest_cache .mypy_cache .coverage
 INSTALL_DIR = ~/Library/'Application Support'/Anki2/addons21/answerset
+
+COVERAGE_FLAGS = --cov=answerset --cov-fail-under=90 --cov-report=term-missing
 
 build: clean test $(OUTPUT_FILE)
 
@@ -21,7 +23,7 @@ clean:
 	rm -rf $(CACHE_DIRS) $(GENERATED_FILES)
 
 test: check
-	$(PYTHON) -m pytest --junitxml=$(TEST_REPORT_FILE)
+	$(PYTHON) -m pytest --junitxml=$(TEST_REPORT_FILE) $(COVERAGE_FLAGS)
 
 check:
 	mypy -p answerset -p test --strict


### PR DESCRIPTION
This PR uses `pytest-cov` to check test coverage when running tests and sets a minimum test coverage of 90% to ensure that all code is tested.